### PR TITLE
fix: ensure breath marks have a spacing with barlines

### DIFF
--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -1491,6 +1491,8 @@ void TLayout::layoutBreath(const Breath* item, Breath::LayoutData* ldata, const 
     }
 
     ldata->setBbox(item->symBbox(item->symId()));
+
+    ldata->setPosX(-ldata->bbox().right() - 0.25 * item->spatium());
 }
 
 void TLayout::layoutChord(Chord* item, LayoutContext& ctx)


### PR DESCRIPTION
Resolves: #4 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

# Description

This PR ensures that breath marks have at least a padding of ` 0.25 * item->spatium()` related to its right barline